### PR TITLE
Merch invoice index

### DIFF
--- a/app/controllers/merchant_invoices_controller.rb
+++ b/app/controllers/merchant_invoices_controller.rb
@@ -1,12 +1,10 @@
 class MerchantInvoicesController < ApplicationController
   def index 
     @merchant = Merchant.find(params[:merchant_id])
-    @invoices = @merchant.invoices
   end
 
   def show
     @merchant = Merchant.find(params[:merchant_id])
     @invoice = @merchant.invoices.find(params[:id])
-    
   end
 end

--- a/app/views/merchant_invoices/index.html.erb
+++ b/app/views/merchant_invoices/index.html.erb
@@ -1,1 +1,10 @@
-<h1><%%= @merchant.name %> Invoices</h1>
+<h1><%= @merchant.name %> Invoice Index Page</h1>
+
+<div id="merchant-invoice-index">
+    <% @merchant.invoices.distinct.each do |invoice| %>
+        <div id="invoice-id-<%= invoice.id %>">
+            <li><%= link_to "Invoice ID: #{invoice.id}", merchant_invoice_path(@merchant, invoice) %></li>
+        </div>
+    <% end %>
+</div>
+

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -1,17 +1,13 @@
 <div id="page-banner">
-
   <div id ="merchant-details">
     <%= @merchant.name %>
   </div>
-
   <div id="merchant-links">
     <%= link_to "Dashboard", "/merchants/#{@merchant.id}", class: "dashboard-link"%>
     <%= link_to 'My Items', "/merchants/#{@merchant.id}/items",class: "items-link" %>
     <%= link_to 'My Invoices', "/merchants/#{@merchant.id}/invoices",class: "invoices-link" %>
   </div>
-
 </div>
-
 
 <div id="dashboard-content">
   <div id="dashboard-content-left">
@@ -31,17 +27,15 @@
           </div>
         <% end %>
       </div>
-
     </div>
   </div>
+  
   <div id="dashboard-content-right">
     <div class="content-column-title">
       Favorite Customers
     </div>
     <div class="content-column-main">
-
       <div id="favorite-customers">
-
         <ol>
           <% @merchant.favorite_customers.each do |customer| %>
             <div id="customer-id-<%= customer.id %>">
@@ -51,9 +45,7 @@
             </div>
           <% end %>
         </ol>
-
       </div>
-
     </div>
   </div>
 </div>

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe 'Dashboard Page' do
     invoice6.transactions.create!(credit_card_number: 2295123422951234, result: 0)
     invoice6.transactions.create!(credit_card_number: 2295123422951234, result: 0)
 
-    visit "/merchants/#{pokemart.id}/dashboard"
+    visit merchant_path(pokemart.id)
 
     within "#customer-id-#{trainer_red.id}" do
       expect(page).to have_content(trainer_red.first_name)

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe 'merchant_invoices index page' do
+    before :each do
+        @pokemart = Merchant.create!(name: 'PokeMart')
+        @potion = @pokemart.items.create!(name: 'Potion', description: 'Recovers 10 HP', unit_price: 2)
+        @super_potion = @pokemart.items.create!(name: 'Super Potion', description: 'Recovers 25 HP', unit_price: 5)
+        @ultra_ball = @pokemart.items.create!(name: 'Ultra Ball', description: 'High chance of catching a Pokemon', unit_price: 8)
+
+        @trainer_red = Customer.create!(first_name: 'Red', last_name: 'Trainer')
+        @invoice1 = @trainer_red.invoices.create!(status: 2)
+        @invoice2 = @trainer_red.invoices.create!(status: 2)
+        @invoice_item1 = InvoiceItem.create!(invoice: @invoice1, item: @ultra_ball, quantity: 2, unit_price: 8, status: 0)
+        @invoice_item2 = InvoiceItem.create!(invoice: @invoice2, item: @super_potion, quantity: 2, unit_price: 5, status: 0)
+        @invoice1.transactions.create!(credit_card_number: 3395123433951234, result: 1)
+        @invoice1.transactions.create!(credit_card_number: 3395123433951234, result: 1)
+        @invoice2.transactions.create!(credit_card_number: 3395123433951234, result: 1)
+        @invoice2.transactions.create!(credit_card_number: 3395123433951234, result: 1)
+
+        @pokegarden = Merchant.create!(name: 'PokeGarden')
+        @razz_berry = @pokegarden.items.create!(name: 'Razz Berry', description: 'Feed this to a Pokémon, and it will be easier to catch on your next throw.', unit_price: 2)
+        @nanab_berry = @pokegarden.items.create!(name: 'Nanab Berry', description: 'Feed this to a Pokémon to calm it down, making it less erratic.', unit_price: 5)
+        @pinap_berry = @pokegarden.items.create!(name: 'Pinap Berry', description: 'Feed this to a Pokémon to make it drop more Candy.', unit_price: 8)
+
+        @trainer_blue = Customer.create!(first_name: 'Blue', last_name: 'Trainer')
+        @invoice3 = @trainer_blue.invoices.create!(status: 2)
+        @invoice4 = @trainer_blue.invoices.create!(status: 2)
+        @invoice_item3 = InvoiceItem.create!(invoice: @invoice3, item: @razz_berry, quantity: 2, unit_price: 8, status: 0)
+        @invoice_item4 = InvoiceItem.create!(invoice: @invoice4, item: @pinap_berry, quantity: 2, unit_price: 5, status: 0)
+        @invoice3.transactions.create!(credit_card_number: 1195123411951234, result: 1)
+        @invoice3.transactions.create!(credit_card_number: 1195123411951234, result: 1)
+        @invoice4.transactions.create!(credit_card_number: 1195123411951234, result: 1)
+        @invoice4.transactions.create!(credit_card_number: 1195123411951234, result: 1)
+    end
+  
+    it 'displays all invoices which include atleast one merchant item and their id' do
+        visit merchant_invoices_path(@pokemart)
+
+        within "#invoice-id-#{@invoice1.id}" do
+            expect(page).to have_content("Invoice ID: #{@invoice1.id}")
+        end
+
+        within "#invoice-id-#{@invoice2.id}" do
+            expect(page).to have_content("Invoice ID: #{@invoice2.id}")
+        end
+
+        within "#merchant-invoice-index" do
+            expect(page).to_not have_content("Invoice ID: #{@invoice3.id}")
+            expect(page).to_not have_content("Invoice ID: #{@invoice4.id}")
+        end
+    end
+
+    it 'links each each invoice to their respective show page' do
+        visit merchant_invoices_path(@pokemart)
+        expect(page).to_not have_content("Invoice ID: #{@invoice3.id}")
+
+        click_on "Invoice ID: #{@invoice1.id}"
+
+        expect(current_path).to eq(merchant_invoice_path(@pokemart, @invoice1))
+    end
+
+    it 'links each each invoice to their respective show page' do
+        visit merchant_invoices_path(@pokegarden)
+        expect(page).to_not have_content("Invoice ID: #{@invoice1.id}")
+
+        click_on "Invoice ID: #{@invoice3.id}"
+
+        expect(current_path).to eq(merchant_invoice_path(@pokegarden, @invoice3))
+    end
+end


### PR DESCRIPTION
Merchant Invoices Index:

- Add Fix: Merchant dashboard spec for top 5 merchants
- Add Test: Display all invoices that include atleast one merchant item in merchant invoice index.
- Add Refactor: Unused @invoices object from merchant invoice controller
- Add Feature: Merchant invoices index page displays merchant invoices with their show page links and rspective IDs.