### PR TITLE
Merch invoice total revenue

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -21,5 +21,9 @@ class Invoice < ApplicationRecord
     valid_invoices =  temp.distinct.joins(:invoice_items)
                           .where.not("invoice_items.status = 2")
   end
+
+  def total_revenue
+    invoice_items.sum('quantity * unit_price')
+  end
 end
 

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -11,8 +11,12 @@
     <%= @invoice.invoice_items.each do |invoice_item|%>
         <h3><%="Item Name: #{invoice_item.item.name}"%></h3>
         <p><%="Quantity Ordered: #{invoice_item.quantity}"%></p>
-        <p><%="Price: #{invoice_item.unit_price}"%></p>
-        <p><%="Status: #{invoice_item.status}"%></p><br>
+        <p><%="Price: #{number_to_currency(invoice_item.unit_price)}"%></p>
+        <p><%="Status: #{invoice_item.status}"%></p>
     <% end %>
+</div>
+
+<div id="invoice-item-total-revenue">
+   <p>Total Revenue: <%= number_to_currency(@invoice.total_revenue) %></p><br>
 </div>
 

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -4,15 +4,15 @@
     <p>ID: <%= @invoice.id %></p>
     <p>Status: <%= @invoice.status %></p>
     <p>Created: <%= @invoice.formatted_date %></p>  
-    <p>Customer: <%= @invoice.customer_name %></p>  
+    <p>Customer: <%= @invoice.customer_name %></p><br>
 </div>
 
 <div id="invoice-item-information">
     <%= @invoice.invoice_items.each do |invoice_item|%>
-        <p><%="Item Name: #{invoice_item.item.name}"%></p>
+        <h3><%="Item Name: #{invoice_item.item.name}"%></h3>
         <p><%="Quantity Ordered: #{invoice_item.quantity}"%></p>
         <p><%="Price: #{invoice_item.unit_price}"%></p>
-        <p><%="Status: #{invoice_item.status}"%></p>
+        <p><%="Status: #{invoice_item.status}"%></p><br>
     <% end %>
 </div>
 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,7 +1,4 @@
-<h2>Welcome to</h2>
-<h1>Little Esty Shop!</h1>
-
-<section>
+<div style="text-align:center">
   <p><%= link_to "Merchant Dashboard Portal", merchant_path(1) %></p>
-  <p><%= link_to "Admin Portal" %></p>
-</section>
+  <p><%= link_to "Admin Dashboard Portal", admin_index_path %></p>
+</div>

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -44,12 +44,41 @@ RSpec.describe 'merchant_invoices show page' do
 
       visit merchant_invoice_path(merch1.id, invoice1.id)
 
-      within('#invoice-item-information') do
+      within "#invoice-item-information" do
         expect(page).to have_content("Item Name: #{invoice_item1.item.name}")
         expect(page).to have_content("Quantity Ordered: #{invoice_item1.quantity}")
-        expect(page).to have_content("Price: #{invoice_item1.unit_price}")
+        expect(page).to have_content("Price: $6.00")
         expect(page).to have_content("Status: #{invoice_item1.status}")
         expect(page).to_not have_content("Item Name: #{invoice_item2.item.name}")
+      end
+  end
+
+  it 'displays total revenue from all items on invoice' do
+      merch1 = Merchant.create!(name: 'Needful Things Imports')
+
+      customer1 = Customer.create!(first_name: 'Bob', last_name: 'Schneider')
+      customer2 = Customer.create!(first_name: 'Veruca', last_name: 'Salt')
+
+      item1 = merch1.items.create!(name: 'Phoenix Feather Wand', description: 'Ergonomic grip', unit_price: 20)
+      item2 = merch1.items.create!(name: 'Harmonica', description: 'Makes pretty noise', unit_price: 6)
+      item3 = merch1.items.create!(name: 'Bag of Holding', description: 'This bag has an interior space considerably larger than its outside dimensions, roughly 2 feet in diameter at the mouth and 4 feet deep.', unit_price: 10)
+      item4 = merch1.items.create!(name: 'Ring of Resonance', description: 'A ring that resonates with the Ring of Flame Lord', unit_price: 15)
+      item5 = merch1.items.create!(name: 'Phreeoni Card', description: 'HIT + 100', unit_price: 20)
+
+      invoice1 = customer1.invoices.create!(status: 1)
+      invoice2 = customer2.invoices.create!(status: 1)
+
+      invoice_item1 = InvoiceItem.create!(invoice: invoice1, item: item1, quantity: 1, unit_price: 20, status: 1)
+      invoice_item1 = InvoiceItem.create!(invoice: invoice1, item: item2, quantity: 2, unit_price: 6, status: 1)
+      invoice_item1 = InvoiceItem.create!(invoice: invoice1, item: item3, quantity: 1, unit_price: 10, status: 1)
+      invoice_item2 = InvoiceItem.create!(invoice: invoice2, item: item4, quantity: 2, unit_price: 15, status: 1)
+      invoice_item2 = InvoiceItem.create!(invoice: invoice2, item: item5, quantity: 1, unit_price: 20, status: 1)
+
+      visit merchant_invoice_path(merch1.id, invoice1.id)
+
+      within "#invoice-item-total-revenue" do
+        expect(page).to have_content("Total Revenue: $42.00")
+        expect(page).to_not have_content("Total Revenue: $50.00")
       end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -25,12 +25,14 @@ RSpec.describe Invoice do
 
       expect(invoice1.formatted_date).to eq('Tuesday, July 26, 2022')
     end
+
     it 'can return a string of the customers full name' do
       customer1 = Customer.create!(first_name: 'Theophania', last_name: 'Fenwick')
       invoice1 = customer1.invoices.create!(status: 1, created_at: '2022-07-26 01:08:32 UTC')
 
       expect(invoice1.customer_name).to eq('Theophania Fenwick')
     end
+
     it 'can return a list of invoices that have not shipped' do
       # (invoice status 1,2...invoice_item status 0,1)
       merch1 = Merchant.create!(name: 'Potions and Things')
@@ -68,6 +70,30 @@ RSpec.describe Invoice do
       expect(invoices.include?(invoice4)).to be(true)
       expect(invoices.include?(invoice5)).to be(false)
       expect(invoices.include?(invoice6)).to be(false)
+    end
+
+    it 'calculates #total_revenue of all items on invoice' do
+      merch1 = Merchant.create!(name: 'Needful Things Imports')
+
+      customer1 = Customer.create!(first_name: 'Bob', last_name: 'Schneider')
+      customer2 = Customer.create!(first_name: 'Veruca', last_name: 'Salt')
+
+      item1 = merch1.items.create!(name: 'Phoenix Feather Wand', description: 'Ergonomic grip', unit_price: 20)
+      item2 = merch1.items.create!(name: 'Harmonica', description: 'Makes pretty noise', unit_price: 6)
+      item3 = merch1.items.create!(name: 'Bag of Holding', description: 'This bag has an interior space considerably larger than its outside dimensions, roughly 2 feet in diameter at the mouth and 4 feet deep.', unit_price: 10)
+      item4 = merch1.items.create!(name: 'Ring of Resonance', description: 'A ring that resonates with the Ring of Flame Lord', unit_price: 15)
+      item5 = merch1.items.create!(name: 'Phreeoni Card', description: 'HIT + 100', unit_price: 20)
+
+      invoice1 = customer1.invoices.create!(status: 1)
+      invoice2 = customer2.invoices.create!(status: 1)
+
+      invoice_item1 = InvoiceItem.create!(invoice: invoice1, item: item1, quantity: 1, unit_price: 20, status: 1)
+      invoice_item1 = InvoiceItem.create!(invoice: invoice1, item: item2, quantity: 2, unit_price: 6, status: 1)
+      invoice_item1 = InvoiceItem.create!(invoice: invoice1, item: item3, quantity: 1, unit_price: 10, status: 1)
+      invoice_item2 = InvoiceItem.create!(invoice: invoice2, item: item4, quantity: 2, unit_price: 15, status: 1)
+      invoice_item2 = InvoiceItem.create!(invoice: invoice2, item: item5, quantity: 1, unit_price: 20, status: 1)
+
+      expect(invoice1.total_revenue).to eq(42)
     end
   end
 end


### PR DESCRIPTION
Merchant invoice show page: total revenue:

- Refactor: Formatting of merchant invoice item information view page.
- Refactor/Add Feature: Welcome index page admin link + centering.
- Add Test: calculates #total_revenue of all items on invoice
- Add Feat: Total revenue invoice model method
- Add Test: displays total revenue from all items on invoice
- Add Feat: Merchant invoice show page can display invoices total items revenue.