### PR TITLE
Fix: merchant_item_update path was broken

### DIFF
--- a/app/views/merchant_items/show.html.erb
+++ b/app/views/merchant_items/show.html.erb
@@ -1,7 +1,7 @@
 <h1> Merchant Item Show Page </h1>
 
 <p id="update-item-link">
-  <%= link_to "Update item", "/merchants/#{@merchant.id}/items/#{@item.id}"%>
+  <%= link_to "Update item", edit_merchant_item_path(@item)%>
 </p>
 
 <p id="item-name">


### PR DESCRIPTION
Fixes the broken "update item" link in the merchant-item-show page. Thanks for finding this @tig-o !